### PR TITLE
fix: add packages write permission for GHCR push

### DIFF
--- a/.github/workflows/build-mcp-docker.yml
+++ b/.github/workflows/build-mcp-docker.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
The GitHub Actions workflow needs explicit packages:write permission to create and push images to GitHub Container Registry.
